### PR TITLE
fix(build): Remove non-existent and unused dependency

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/Home24/Category-Service/src/interfaces"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"


### PR DESCRIPTION
Hey. Thanks for sharing the awesome project!

I was unable to build this project due to that the pkg `github.com/Home24/Category-Service/src/interfaces` that it depends is [nowhere](http://github.com/Home24/Category-Service).

Fortunately, we can remove it safely because it is unused :)